### PR TITLE
Beer basic implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ DerivedData
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
-# Pods/
+Pods/
 
 # Carthage
 #

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 /* Begin PBXFileReference section */
 		233ECF021C4063A40050971B /* BeerRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequest.swift; sourceTree = "<group>"; };
 		233ECF041C4063CC0050971B /* BeerRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequestTests.swift; sourceTree = "<group>"; };
+		23561F2D1C70EB8F00B2454A /* BreweryDBTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BreweryDBTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		23DF758A1C5D0E9C00D5D218 /* RequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		23DF758C1C5D14D700D5D218 /* RequestBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
 		23FF53C21C397A7B0094249C /* BreweryDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BreweryDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -118,6 +119,7 @@
 				23FF53E71C3985760094249C /* BeerTests.swift */,
 				233ECF041C4063CC0050971B /* BeerRequestTests.swift */,
 				23DF758C1C5D14D700D5D218 /* RequestBuilderTests.swift */,
+				23561F2D1C70EB8F00B2454A /* BreweryDBTests-Bridging-Header.h */,
 			);
 			path = BreweryDBTests;
 			sourceTree = "<group>";
@@ -464,11 +466,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9DE5DF23C3227D92002200AE /* Pods-BreweryDBTests.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = BreweryDBTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDBTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BreweryDBTests/BreweryDBTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -476,11 +481,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6D6E09977C417B5C266478E3 /* Pods-BreweryDBTests.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = BreweryDBTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDBTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BreweryDBTests/BreweryDBTests-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53D11C397A7B0094249C /* BreweryDBTests.swift */; };
 		23FF53DD1C397ED70094249C /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53DC1C397ED70094249C /* Alamofire.framework */; };
 		23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E31C39831B0094249C /* BreweryDB.swift */; };
+		23FF53E61C3985660094249C /* Beer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E51C3985660094249C /* Beer.swift */; };
+		23FF53E81C3985760094249C /* BeerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E71C3985760094249C /* BeerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +35,8 @@
 		23FF53D31C397A7B0094249C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		23FF53DC1C397ED70094249C /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		23FF53E31C39831B0094249C /* BreweryDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreweryDB.swift; sourceTree = "<group>"; };
+		23FF53E51C3985660094249C /* Beer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Beer.swift; sourceTree = "<group>"; };
+		23FF53E71C3985760094249C /* BeerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +84,7 @@
 				23FF53C51C397A7B0094249C /* BreweryDB.h */,
 				23FF53C71C397A7B0094249C /* Info.plist */,
 				23FF53E31C39831B0094249C /* BreweryDB.swift */,
+				23FF53E51C3985660094249C /* Beer.swift */,
 			);
 			path = BreweryDB;
 			sourceTree = "<group>";
@@ -89,6 +94,7 @@
 			children = (
 				23FF53D11C397A7B0094249C /* BreweryDBTests.swift */,
 				23FF53D31C397A7B0094249C /* Info.plist */,
+				23FF53E71C3985760094249C /* BeerTests.swift */,
 			);
 			path = BreweryDBTests;
 			sourceTree = "<group>";
@@ -220,6 +226,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */,
+				23FF53E61C3985660094249C /* Beer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,6 +235,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */,
+				23FF53E81C3985760094249C /* BeerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		233ECF031C4063A40050971B /* BeerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233ECF021C4063A40050971B /* BeerRequest.swift */; };
+		233ECF051C4063CC0050971B /* BeerRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233ECF041C4063CC0050971B /* BeerRequestTests.swift */; };
 		23FF53C61C397A7B0094249C /* BreweryDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FF53C51C397A7B0094249C /* BreweryDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53C21C397A7B0094249C /* BreweryDB.framework */; };
 		23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53D11C397A7B0094249C /* BreweryDBTests.swift */; };
@@ -29,6 +30,7 @@
 
 /* Begin PBXFileReference section */
 		233ECF021C4063A40050971B /* BeerRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequest.swift; sourceTree = "<group>"; };
+		233ECF041C4063CC0050971B /* BeerRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequestTests.swift; sourceTree = "<group>"; };
 		23FF53C21C397A7B0094249C /* BreweryDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BreweryDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		23FF53C51C397A7B0094249C /* BreweryDB.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BreweryDB.h; sourceTree = "<group>"; };
 		23FF53C71C397A7B0094249C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 				23FF53D11C397A7B0094249C /* BreweryDBTests.swift */,
 				23FF53D31C397A7B0094249C /* Info.plist */,
 				23FF53E71C3985760094249C /* BeerTests.swift */,
+				233ECF041C4063CC0050971B /* BeerRequestTests.swift */,
 			);
 			path = BreweryDBTests;
 			sourceTree = "<group>";
@@ -241,6 +244,7 @@
 			files = (
 				23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */,
 				23FF53E81C3985760094249C /* BeerTests.swift in Sources */,
+				233ECF051C4063CC0050971B /* BeerRequestTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -421,10 +421,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = BreweryDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
@@ -447,10 +444,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = BreweryDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		233ECF031C4063A40050971B /* BeerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233ECF021C4063A40050971B /* BeerRequest.swift */; };
 		233ECF051C4063CC0050971B /* BeerRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233ECF041C4063CC0050971B /* BeerRequestTests.swift */; };
+		23DF758B1C5D0E9C00D5D218 /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23DF758A1C5D0E9C00D5D218 /* RequestBuilder.swift */; };
 		23FF53C61C397A7B0094249C /* BreweryDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FF53C51C397A7B0094249C /* BreweryDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53C21C397A7B0094249C /* BreweryDB.framework */; };
 		23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53D11C397A7B0094249C /* BreweryDBTests.swift */; };
@@ -31,6 +32,7 @@
 /* Begin PBXFileReference section */
 		233ECF021C4063A40050971B /* BeerRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequest.swift; sourceTree = "<group>"; };
 		233ECF041C4063CC0050971B /* BeerRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequestTests.swift; sourceTree = "<group>"; };
+		23DF758A1C5D0E9C00D5D218 /* RequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
 		23FF53C21C397A7B0094249C /* BreweryDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BreweryDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		23FF53C51C397A7B0094249C /* BreweryDB.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BreweryDB.h; sourceTree = "<group>"; };
 		23FF53C71C397A7B0094249C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 				23FF53E31C39831B0094249C /* BreweryDB.swift */,
 				23FF53E51C3985660094249C /* Beer.swift */,
 				233ECF021C4063A40050971B /* BeerRequest.swift */,
+				23DF758A1C5D0E9C00D5D218 /* RequestBuilder.swift */,
 			);
 			path = BreweryDB;
 			sourceTree = "<group>";
@@ -235,6 +238,7 @@
 				23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */,
 				23FF53E61C3985660094249C /* Beer.swift in Sources */,
 				233ECF031C4063A40050971B /* BeerRequest.swift in Sources */,
+				23DF758B1C5D0E9C00D5D218 /* RequestBuilder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		233ECF031C4063A40050971B /* BeerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233ECF021C4063A40050971B /* BeerRequest.swift */; };
 		233ECF051C4063CC0050971B /* BeerRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233ECF041C4063CC0050971B /* BeerRequestTests.swift */; };
 		23DF758B1C5D0E9C00D5D218 /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23DF758A1C5D0E9C00D5D218 /* RequestBuilder.swift */; };
+		23DF758D1C5D14D700D5D218 /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23DF758C1C5D14D700D5D218 /* RequestBuilderTests.swift */; };
 		23FF53C61C397A7B0094249C /* BreweryDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FF53C51C397A7B0094249C /* BreweryDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53C21C397A7B0094249C /* BreweryDB.framework */; };
 		23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53D11C397A7B0094249C /* BreweryDBTests.swift */; };
@@ -33,6 +34,7 @@
 		233ECF021C4063A40050971B /* BeerRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequest.swift; sourceTree = "<group>"; };
 		233ECF041C4063CC0050971B /* BeerRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequestTests.swift; sourceTree = "<group>"; };
 		23DF758A1C5D0E9C00D5D218 /* RequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
+		23DF758C1C5D14D700D5D218 /* RequestBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
 		23FF53C21C397A7B0094249C /* BreweryDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BreweryDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		23FF53C51C397A7B0094249C /* BreweryDB.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BreweryDB.h; sourceTree = "<group>"; };
 		23FF53C71C397A7B0094249C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 				23FF53D31C397A7B0094249C /* Info.plist */,
 				23FF53E71C3985760094249C /* BeerTests.swift */,
 				233ECF041C4063CC0050971B /* BeerRequestTests.swift */,
+				23DF758C1C5D14D700D5D218 /* RequestBuilderTests.swift */,
 			);
 			path = BreweryDBTests;
 			sourceTree = "<group>";
@@ -249,6 +252,7 @@
 				23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */,
 				23FF53E81C3985760094249C /* BeerTests.swift in Sources */,
 				233ECF051C4063CC0050971B /* BeerRequestTests.swift in Sources */,
+				23DF758D1C5D14D700D5D218 /* RequestBuilderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 				);
 				INFOPLIST_FILE = BreweryDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -381,6 +382,7 @@
 				);
 				INFOPLIST_FILE = BreweryDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -393,6 +395,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = BreweryDBTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDBTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -403,6 +406,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = BreweryDBTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDBTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E31C39831B0094249C /* BreweryDB.swift */; };
 		23FF53E61C3985660094249C /* Beer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E51C3985660094249C /* Beer.swift */; };
 		23FF53E81C3985760094249C /* BeerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E71C3985760094249C /* BeerTests.swift */; };
-		5AB5021869050C2D6C6D7938 /* libPods-BreweryDBTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 717A43A5629EAA594B3F3A31 /* libPods-BreweryDBTests.a */; };
+		39300FC8453F9B4B9A1322F5 /* Pods_BreweryDBTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8B9A98A1C0E7F897267F299 /* Pods_BreweryDBTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,8 +45,8 @@
 		23FF53E51C3985660094249C /* Beer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Beer.swift; sourceTree = "<group>"; };
 		23FF53E71C3985760094249C /* BeerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerTests.swift; sourceTree = "<group>"; };
 		6D6E09977C417B5C266478E3 /* Pods-BreweryDBTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BreweryDBTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BreweryDBTests/Pods-BreweryDBTests.release.xcconfig"; sourceTree = "<group>"; };
-		717A43A5629EAA594B3F3A31 /* libPods-BreweryDBTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BreweryDBTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9DE5DF23C3227D92002200AE /* Pods-BreweryDBTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BreweryDBTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BreweryDBTests/Pods-BreweryDBTests.debug.xcconfig"; sourceTree = "<group>"; };
+		A8B9A98A1C0E7F897267F299 /* Pods_BreweryDBTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BreweryDBTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,7 +62,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */,
-				5AB5021869050C2D6C6D7938 /* libPods-BreweryDBTests.a in Frameworks */,
+				39300FC8453F9B4B9A1322F5 /* Pods_BreweryDBTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -72,7 +72,7 @@
 		05A96B4A1A4D76C91CDA2DBA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				717A43A5629EAA594B3F3A31 /* libPods-BreweryDBTests.a */,
+				A8B9A98A1C0E7F897267F299 /* Pods_BreweryDBTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E31C39831B0094249C /* BreweryDB.swift */; };
 		23FF53E61C3985660094249C /* Beer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E51C3985660094249C /* Beer.swift */; };
 		23FF53E81C3985760094249C /* BeerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E71C3985760094249C /* BeerTests.swift */; };
+		5AB5021869050C2D6C6D7938 /* libPods-BreweryDBTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 717A43A5629EAA594B3F3A31 /* libPods-BreweryDBTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,10 +41,12 @@
 		23FF53CC1C397A7B0094249C /* BreweryDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BreweryDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		23FF53D11C397A7B0094249C /* BreweryDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreweryDBTests.swift; sourceTree = "<group>"; };
 		23FF53D31C397A7B0094249C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		23FF53DC1C397ED70094249C /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		23FF53E31C39831B0094249C /* BreweryDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreweryDB.swift; sourceTree = "<group>"; };
 		23FF53E51C3985660094249C /* Beer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Beer.swift; sourceTree = "<group>"; };
 		23FF53E71C3985760094249C /* BeerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerTests.swift; sourceTree = "<group>"; };
+		6D6E09977C417B5C266478E3 /* Pods-BreweryDBTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BreweryDBTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BreweryDBTests/Pods-BreweryDBTests.release.xcconfig"; sourceTree = "<group>"; };
+		717A43A5629EAA594B3F3A31 /* libPods-BreweryDBTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BreweryDBTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9DE5DF23C3227D92002200AE /* Pods-BreweryDBTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BreweryDBTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BreweryDBTests/Pods-BreweryDBTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,19 +62,29 @@
 			buildActionMask = 2147483647;
 			files = (
 				23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */,
+				5AB5021869050C2D6C6D7938 /* libPods-BreweryDBTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		05A96B4A1A4D76C91CDA2DBA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				717A43A5629EAA594B3F3A31 /* libPods-BreweryDBTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		23FF53B81C397A7B0094249C = {
 			isa = PBXGroup;
 			children = (
-				23FF53DC1C397ED70094249C /* Alamofire.framework */,
 				23FF53C41C397A7B0094249C /* BreweryDB */,
 				23FF53D01C397A7B0094249C /* BreweryDBTests */,
 				23FF53C31C397A7B0094249C /* Products */,
+				301A9BEC1D3A337499F5A2A8 /* Pods */,
+				05A96B4A1A4D76C91CDA2DBA /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -107,6 +120,15 @@
 				23DF758C1C5D14D700D5D218 /* RequestBuilderTests.swift */,
 			);
 			path = BreweryDBTests;
+			sourceTree = "<group>";
+		};
+		301A9BEC1D3A337499F5A2A8 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9DE5DF23C3227D92002200AE /* Pods-BreweryDBTests.debug.xcconfig */,
+				6D6E09977C417B5C266478E3 /* Pods-BreweryDBTests.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -145,9 +167,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 23FF53D91C397A7B0094249C /* Build configuration list for PBXNativeTarget "BreweryDBTests" */;
 			buildPhases = (
+				9A97658A2D048E026AB9384C /* Check Pods Manifest.lock */,
 				23FF53C81C397A7B0094249C /* Sources */,
 				23FF53C91C397A7B0094249C /* Frameworks */,
 				23FF53CA1C397A7B0094249C /* Resources */,
+				D7EAC6DCD8DF39174CA9FB7D /* Embed Pods Frameworks */,
+				0917E24DA1233F0CC99E6991 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -212,6 +237,54 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0917E24DA1233F0CC99E6991 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BreweryDBTests/Pods-BreweryDBTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9A97658A2D048E026AB9384C /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		D7EAC6DCD8DF39174CA9FB7D /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BreweryDBTests/Pods-BreweryDBTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		23FF53BD1C397A7B0094249C /* Sources */ = {
@@ -389,6 +462,7 @@
 		};
 		23FF53DA1C397A7B0094249C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9DE5DF23C3227D92002200AE /* Pods-BreweryDBTests.debug.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = BreweryDBTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
@@ -400,6 +474,7 @@
 		};
 		23FF53DB1C397A7B0094249C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6D6E09977C417B5C266478E3 /* Pods-BreweryDBTests.release.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = BreweryDBTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		23FF53C61C397A7B0094249C /* BreweryDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FF53C51C397A7B0094249C /* BreweryDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53C21C397A7B0094249C /* BreweryDB.framework */; };
 		23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53D11C397A7B0094249C /* BreweryDBTests.swift */; };
-		23FF53DD1C397ED70094249C /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53DC1C397ED70094249C /* Alamofire.framework */; };
 		23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E31C39831B0094249C /* BreweryDB.swift */; };
 		23FF53E61C3985660094249C /* Beer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E51C3985660094249C /* Beer.swift */; };
 		23FF53E81C3985760094249C /* BeerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E71C3985760094249C /* BeerTests.swift */; };
@@ -52,7 +51,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				23FF53DD1C397ED70094249C /* Alamofire.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,7 +131,6 @@
 				23FF53BE1C397A7B0094249C /* Frameworks */,
 				23FF53BF1C397A7B0094249C /* Headers */,
 				23FF53C01C397A7B0094249C /* Resources */,
-				23FF53DE1C397F380094249C /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -215,23 +212,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		23FF53DE1C397F380094249C /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		23FF53BD1C397A7B0094249C /* Sources */ = {

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 				TargetAttributes = {
 					23FF53C11C397A7B0094249C = {
 						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = 5SLHXDMNZ3;
 					};
 					23FF53CB1C397A7B0094249C = {
 						CreatedOnToolsVersion = 7.2;
@@ -343,6 +344,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -356,6 +359,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -365,6 +369,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -378,6 +384,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		233ECF031C4063A40050971B /* BeerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233ECF021C4063A40050971B /* BeerRequest.swift */; };
 		23FF53C61C397A7B0094249C /* BreweryDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FF53C51C397A7B0094249C /* BreweryDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53C21C397A7B0094249C /* BreweryDB.framework */; };
 		23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53D11C397A7B0094249C /* BreweryDBTests.swift */; };
@@ -27,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		233ECF021C4063A40050971B /* BeerRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BeerRequest.swift; sourceTree = "<group>"; };
 		23FF53C21C397A7B0094249C /* BreweryDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BreweryDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		23FF53C51C397A7B0094249C /* BreweryDB.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BreweryDB.h; sourceTree = "<group>"; };
 		23FF53C71C397A7B0094249C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 				23FF53C71C397A7B0094249C /* Info.plist */,
 				23FF53E31C39831B0094249C /* BreweryDB.swift */,
 				23FF53E51C3985660094249C /* Beer.swift */,
+				233ECF021C4063A40050971B /* BeerRequest.swift */,
 			);
 			path = BreweryDB;
 			sourceTree = "<group>";
@@ -228,6 +231,7 @@
 			files = (
 				23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */,
 				23FF53E61C3985660094249C /* Beer.swift in Sources */,
+				233ECF031C4063A40050971B /* BeerRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BreweryDB.xcodeproj/project.pbxproj
+++ b/BreweryDB.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		23FF53CD1C397A7B0094249C /* BreweryDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53C21C397A7B0094249C /* BreweryDB.framework */; };
 		23FF53D21C397A7B0094249C /* BreweryDBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53D11C397A7B0094249C /* BreweryDBTests.swift */; };
 		23FF53DD1C397ED70094249C /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23FF53DC1C397ED70094249C /* Alamofire.framework */; };
+		23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FF53E31C39831B0094249C /* BreweryDB.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +32,7 @@
 		23FF53D11C397A7B0094249C /* BreweryDBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreweryDBTests.swift; sourceTree = "<group>"; };
 		23FF53D31C397A7B0094249C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		23FF53DC1C397ED70094249C /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
+		23FF53E31C39831B0094249C /* BreweryDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreweryDB.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +79,7 @@
 			children = (
 				23FF53C51C397A7B0094249C /* BreweryDB.h */,
 				23FF53C71C397A7B0094249C /* Info.plist */,
+				23FF53E31C39831B0094249C /* BreweryDB.swift */,
 			);
 			path = BreweryDB;
 			sourceTree = "<group>";
@@ -216,6 +219,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23FF53E41C39831B0094249C /* BreweryDB.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -330,6 +334,7 @@
 		23FF53D71C397A7B0094249C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -344,12 +349,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.jakewelton.BreweryDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		23FF53D81C397A7B0094249C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/BreweryDB.xcworkspace/contents.xcworkspacedata
+++ b/BreweryDB.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BreweryDB.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/BreweryDB/Beer.swift
+++ b/BreweryDB/Beer.swift
@@ -1,0 +1,13 @@
+//
+//  Beer.swift
+//  BreweryDB
+//
+//  Created by Jake Welton on 1/3/16.
+//  Copyright © 2016 Jake Welton. All rights reserved.
+//
+
+import Foundation
+
+class Beer {
+    
+}

--- a/BreweryDB/Beer.swift
+++ b/BreweryDB/Beer.swift
@@ -9,4 +9,25 @@
 import Foundation
 
 class Beer {
+    var identifier: String?
+    var name: String?
+    var description: String?
+    var foodPairings: String?
+    var originalGravity: String?
+    var abv: String?
+    var ibu: String?
+    var glasswareId: String?
+    var glass: String?
+    var styleId: String?
+    var style: String?
+    var isOrganic: Bool?
+    var labels: String?
+    var servingTemperature: String?
+    var servingTemperatureDisplay: String?
+    var status: String?
+    var statusDisplay: String?
+    var availableId: String?
+    var available: String?
+    var beerVariation: String?
+    var year: String?
 }

--- a/BreweryDB/Beer.swift
+++ b/BreweryDB/Beer.swift
@@ -9,5 +9,10 @@
 import Foundation
 
 class Beer {
-    
+    init(name: String) {}
+    init(abv: String) {}
+    init(ibu: String) {}
+    init(srmId: String) {}
+    init(availabilityId: String) {}
+    init(styleId: String) {}
 }

--- a/BreweryDB/Beer.swift
+++ b/BreweryDB/Beer.swift
@@ -9,10 +9,5 @@
 import Foundation
 
 class Beer {
-    init(name: String) {}
-    init(abv: String) {}
-    init(ibu: String) {}
-    init(srmId: String) {}
-    init(availabilityId: String) {}
-    init(styleId: String) {}
+    init(identifier: String) {}
 }

--- a/BreweryDB/Beer.swift
+++ b/BreweryDB/Beer.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 class Beer {
-    var identifier: String?
+    let identifier: String
     var name: String?
     var description: String?
     var foodPairings: String?
@@ -31,5 +31,7 @@ class Beer {
     var beerVariation: String?
     var year: String?
     
-    init(identifier: String) {}
+    init(identifier: String) {
+        self.identifier = identifier
+    }
 }

--- a/BreweryDB/Beer.swift
+++ b/BreweryDB/Beer.swift
@@ -9,10 +9,4 @@
 import Foundation
 
 class Beer {
-    init(name: String) {}
-    init(abv: String) {}
-    init(ibu: String) {}
-    init(srmId: String) {}
-    init(availabilityId: String) {}
-    init(styleId: String) {}
 }

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -1,0 +1,13 @@
+//
+//  BeerRequest.swift
+//  BreweryDB
+//
+//  Created by Jake on 08/01/2016.
+//  Copyright © 2016 Jake Welton. All rights reserved.
+//
+
+import Foundation
+
+class BeerRequest {
+    
+}

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -36,4 +36,8 @@ class BeerRequest {
         
         requestParams = params
     }
+    
+    func loadBeersWithCompletionHandler(completionHandler: ((beers: [Beer])->Void)) {
+        BreweryDBApiKey
+    }
 }

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -27,7 +27,7 @@ enum BeerRequestParam: String {
 
 class BeerRequest {
     let requestParams: [BeerRequestParam: String]
-    let requestBuilder = RequestBuilder(endPoint: .Beer)
+    let requestBuilder = RequestBuilder(endPoint: .Beers)
     
     init?(requestParams params: [BeerRequestParam: String]) {
         if params.count == 0 {

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -26,5 +26,14 @@ enum BeerRequestParam {
 }
 
 class BeerRequest {
+    let requestParams: [BeerRequestParam: String]
     
+    init?(requestParams params: [BeerRequestParam: String]) {
+        if params.count == 0 {
+            requestParams = [:]
+            return nil
+        }
+        
+        requestParams = params
+    }
 }

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -44,6 +44,19 @@ class BeerRequest {
             return
         }
         
+        let urlRequest = NSURLRequest(URL: url)
         
+        NSURLSession.sharedSession().dataTaskWithRequest(urlRequest) { data, response, error in
+            guard let returnedData = data,
+                let response = response as? NSHTTPURLResponse where response.statusCode == 200,
+                let stringData = String(data: returnedData, encoding: NSUTF8StringEncoding) else {
+                    completionHandler(beers: nil)
+                    return
+            }
+            
+            let beer = Beer(identifier: stringData)
+            
+            completionHandler(beers: [beer])
+            }.resume()
     }
 }

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -27,6 +27,7 @@ enum BeerRequestParam: String {
 
 class BeerRequest {
     let requestParams: [BeerRequestParam: String]
+    let requestBuilder = RequestBuilder(endPoint: .Beer)
     
     init?(requestParams params: [BeerRequestParam: String]) {
         if params.count == 0 {
@@ -38,6 +39,6 @@ class BeerRequest {
     }
     
     func loadBeersWithCompletionHandler(completionHandler: ((beers: [Beer])->Void)) {
-        
+        let url = requestBuilder.buildRequest(requestParams)
     }
 }

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -8,6 +8,23 @@
 
 import Foundation
 
+enum BeerRequestParam {
+    case Identifier
+    case Name
+    case Abv
+    case Ibu
+    case GlasswareId
+    case SrmId
+    case AvaliableId
+    case StyleId
+    case IsOrganic
+    case HasLabels
+    case Year
+    case Since
+    case Status
+    case RandomCount
+}
+
 class BeerRequest {
     
 }

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -31,7 +31,6 @@ class BeerRequest {
     
     init?(requestParams params: [BeerRequestParam: String]) {
         if params.count == 0 {
-            requestParams = [:]
             return nil
         }
         

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -8,21 +8,21 @@
 
 import Foundation
 
-enum BeerRequestParam {
-    case Identifier
-    case Name
-    case Abv
-    case Ibu
-    case GlasswareId
-    case SrmId
-    case AvaliableId
-    case StyleId
-    case IsOrganic
-    case HasLabels
-    case Year
-    case Since
-    case Status
-    case RandomCount
+enum BeerRequestParam: String {
+    case Identifier = "ids"
+    case Name = "name"
+    case Abv = "abv"
+    case Ibu = "ibu"
+    case GlasswareId = "glasswareId"
+    case SrmId = "srmId"
+    case AvaliableId = "availableId"
+    case StyleId = "styleId"
+    case IsOrganic = "isOrganic"
+    case HasLabels = "hasLabels"
+    case Year = "year"
+    case Since = "since"
+    case Status = "status"
+    case RandomCount = "order"
 }
 
 class BeerRequest {

--- a/BreweryDB/BeerRequest.swift
+++ b/BreweryDB/BeerRequest.swift
@@ -38,7 +38,12 @@ class BeerRequest {
         requestParams = params
     }
     
-    func loadBeersWithCompletionHandler(completionHandler: ((beers: [Beer])->Void)) {
-        let url = requestBuilder.buildRequest(requestParams)
+    func loadBeersWithCompletionHandler(completionHandler: ((beers: [Beer]?)->Void)) {
+        guard let url = requestBuilder.buildRequest(requestParams) else {
+            completionHandler(beers: nil)
+            return
+        }
+        
+        
     }
 }

--- a/BreweryDB/BreweryDB.swift
+++ b/BreweryDB/BreweryDB.swift
@@ -9,3 +9,4 @@
 import Foundation
 
 public var BreweryDBApiKey: String? = nil
+public let BreweryDBBaseURL = "http://api.brewerydb.com/v2/"

--- a/BreweryDB/BreweryDB.swift
+++ b/BreweryDB/BreweryDB.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 public var BreweryDBApiKey: String? = nil
-public let BreweryDBBaseURL = "http://api.brewerydb.com/v2/"
+public let BreweryDBBaseURL = NSURL(string: "http://api.brewerydb.com/v2/")!

--- a/BreweryDB/BreweryDB.swift
+++ b/BreweryDB/BreweryDB.swift
@@ -9,4 +9,4 @@
 import Foundation
 
 public var BreweryDBApiKey: String? = nil
-public let BreweryDBBaseURL = NSURL(string: "http://api.brewerydb.com/v2/")!
+public let BreweryDBBaseURL = NSURL(string: "http://api.brewerydb.com/v2")!

--- a/BreweryDB/BreweryDB.swift
+++ b/BreweryDB/BreweryDB.swift
@@ -1,0 +1,11 @@
+//
+//  BreweryDB.swift
+//  BreweryDB
+//
+//  Created by Jake Welton on 1/3/16.
+//  Copyright © 2016 Jake Welton. All rights reserved.
+//
+
+import Foundation
+
+public var BreweryDBApiKey: String? = nil

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+enum RequestEndPoint: String {
+    case Beer = "beer"
+    case Beers = "beers"
+}
 class RequestBuilder {
     
 }

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 enum RequestEndPoint: String {
-    case Beer = "beer"
     case Beers = "beers"
 }
 

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -20,5 +20,9 @@ extension NSURL {
 }
 
 class RequestBuilder {
+    let endPoint: RequestEndPoint
     
+    init(endPoint: RequestEndPoint) {
+        self.endPoint = endPoint
+    }
 }

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -1,0 +1,13 @@
+//
+//  RequestBuilder.swift
+//  BreweryDB
+//
+//  Created by Jake Welton on 1/30/16.
+//  Copyright © 2016 Jake Welton. All rights reserved.
+//
+
+import Foundation
+
+class RequestBuilder {
+    
+}

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -17,9 +17,8 @@ extension NSURL {
         return URLByAppendingPathComponent(endPoint.rawValue)
     }
     
-    func URLByAppendingGETVariable<T : RawRepresentable where T.RawValue == String>(param: T, value: String, isFirstVar: Bool) -> NSURL {
-        let url = isFirstVar ? "?" : "&"
-        let path = url + param.rawValue + "=" + value
+    func URLByAppendingGETVariable<T : RawRepresentable where T.RawValue == String>(param: T, value: String) -> NSURL {
+        let path = "&" + param.rawValue + "=" + value
         return NSURL(string: self.absoluteString + path)!
     }
 }

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -30,11 +30,17 @@ class RequestBuilder {
         self.endPoint = endPoint
     }
     
-    func buildRequest<T : RawRepresentable where T.RawValue == String>(requestParams: [T: String]) -> NSURL {
-        var beerRequest = BreweryDBBaseURL.URLByAppendingPathComponent(endPoint)
+    func buildRequest<T : RawRepresentable where T.RawValue == String>(requestParams: [T: String]) -> NSURL? {
+        let baseURL = BreweryDBBaseURL.URLByAppendingPathComponent(endPoint)
         
-        for (index, param) in requestParams.enumerate() {
-            beerRequest = beerRequest.URLByAppendingGETVariable(param.0, value: param.1, isFirstVar: index == 0 ? true : false)
+        guard let apiKey = BreweryDBApiKey,
+            var beerRequest = NSURL(string: baseURL.absoluteString + "?key=\(apiKey)") else {
+                print("BreweryDB: Failed to build base URL. Have you set your BreweryDB API key?")
+                return nil
+        }
+        
+        for param in requestParams {
+            beerRequest = beerRequest.URLByAppendingGETVariable(param.0, value: param.1)
         }
         
         return beerRequest

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -21,7 +21,7 @@ extension NSURL {
     func URLByAppendingGETVariable<T : RawRepresentable where T.RawValue == String>(param: T, value: String, isFirstVar: Bool) -> NSURL {
         let url = isFirstVar ? "?" : "&"
         let path = url + param.rawValue + "=" + value
-        return NSURL(string: self.path! + path)!
+        return NSURL(string: self.absoluteString + path)!
     }
 }
 

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -17,6 +17,12 @@ extension NSURL {
     func URLByAppendingPathComponent(endPoint: RequestEndPoint) -> NSURL {
         return URLByAppendingPathComponent(endPoint.rawValue)
     }
+    
+    func URLByAppendingGETVariable<T : RawRepresentable where T.RawValue == String>(param: T, value: String, isFirstVar: Bool) -> NSURL {
+        let url = isFirstVar ? "?" : "&"
+        let path = url + param.rawValue + "=" + value
+        return NSURL(string: self.path! + path)!
+    }
 }
 
 class RequestBuilder {
@@ -27,11 +33,10 @@ class RequestBuilder {
     }
     
     func buildRequest<T : RawRepresentable where T.RawValue == String>(requestParams: [T: String]) -> NSURL {
-        let beerRequest = BreweryDBBaseURL.URLByAppendingPathComponent(endPoint)
+        var beerRequest = BreweryDBBaseURL.URLByAppendingPathComponent(endPoint)
         
-        for param in requestParams {
-            beerRequest.URLByAppendingPathComponent(param.0.rawValue)
-            beerRequest.URLByAppendingPathComponent(param.1)
+        for (index, param) in requestParams.enumerate() {
+            beerRequest = beerRequest.URLByAppendingGETVariable(param.0, value: param.1, isFirstVar: index == 0 ? true : false)
         }
         
         return beerRequest

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -12,6 +12,13 @@ enum RequestEndPoint: String {
     case Beer = "beer"
     case Beers = "beers"
 }
+
+extension NSURL {
+    func URLByAppendingPathComponent(endPoint: RequestEndPoint) -> NSURL {
+        return URLByAppendingPathComponent(endPoint.rawValue)
+    }
+}
+
 class RequestBuilder {
     
 }

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -24,6 +24,7 @@ extension NSURL {
 }
 
 class RequestBuilder {
+    let bugFix = ""
     let endPoint: RequestEndPoint
     
     init(endPoint: RequestEndPoint) {

--- a/BreweryDB/RequestBuilder.swift
+++ b/BreweryDB/RequestBuilder.swift
@@ -25,4 +25,15 @@ class RequestBuilder {
     init(endPoint: RequestEndPoint) {
         self.endPoint = endPoint
     }
+    
+    func buildRequest<T : RawRepresentable where T.RawValue == String>(requestParams: [T: String]) -> NSURL {
+        let beerRequest = BreweryDBBaseURL.URLByAppendingPathComponent(endPoint)
+        
+        for param in requestParams {
+            beerRequest.URLByAppendingPathComponent(param.0.rawValue)
+            beerRequest.URLByAppendingPathComponent(param.1)
+        }
+        
+        return beerRequest
+    }
 }

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -13,12 +13,19 @@ class BeerRequestTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
+        
+        stub(isHost(BreweryDBBaseURL.absoluteString)) { _ in
+            let stubData = "Hello World!".dataUsingEncoding(NSUTF8StringEncoding)
+            return OHHTTPStubsResponse(data: stubData!, statusCode:200, headers:nil)
+        }
+        
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+        OHHTTPStubs.removeAllStubs()
     }
     
     func testBeerCanBeInitialized() {

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -98,4 +98,28 @@ class BeerRequestTests: XCTestCase {
         }
     }
     
+    func testBeerRequestLoadBeersWithNoConnectionReturnsNil() {
+        stub(isHost("api.brewerydb.com")) { _ in
+            let notConnectedError = NSError(domain:NSURLErrorDomain, code:Int(CFNetworkErrors.CFURLErrorNotConnectedToInternet.rawValue), userInfo:nil)
+            return OHHTTPStubsResponse(error:notConnectedError)
+        }
+        
+        let expectation = expectationWithDescription("URL request should return within 5 seconds")
+        let requestParams = [ BeerRequestParam.Identifier: "NTrt0Z" ]
+        
+        guard let request = BeerRequest(requestParams: requestParams) else {
+            XCTFail("Beer request initialisation should not fail")
+            return
+        }
+        
+        request.loadBeersWithCompletionHandler() { beers in
+            XCTAssertNil(beers)
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(5) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
 }

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -77,4 +77,25 @@ class BeerRequestTests: XCTestCase {
         }
     }
     
+    func testBeerRequestLoadBeersWithNilAPIKeyReturnsNil() {
+        let expectation = expectationWithDescription("Beers should return nil")
+        let requestParams = [ BeerRequestParam.Identifier: "NTrt0Z" ]
+        
+        BreweryDBApiKey = nil
+        
+        guard let request = BeerRequest(requestParams: requestParams) else {
+            XCTFail("Beer request initialisation should not fail")
+            return
+        }
+        
+        request.loadBeersWithCompletionHandler { beers in
+            XCTAssertNil(beers)
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(5) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
 }

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @testable import BreweryDB
 
 class BeerRequestTests: XCTestCase {
+    let returnData = "Test Data"
     
     override func setUp() {
         super.setUp()
@@ -50,6 +51,29 @@ class BeerRequestTests: XCTestCase {
         var request: BeerRequest? = BeerRequest(requestParams: requestParams)
         request = nil
         XCTAssertNil(request)
+    }
+    
+    func testBeerRequestLoadBeersWithBeerIdReturnsSuccessful() {
+        stub(isHost("api.brewerydb.com")) { _ in
+            let stubData = returnData.dataUsingEncoding(NSUTF8StringEncoding)
+            return OHHTTPStubsResponse(data: stubData!, statusCode:200, headers:nil)
+        }
+        
+        let expectation = expectationWithDescription("URL request should return within 5 seconds")
+        let requestParams = [ BeerRequestParam.Identifier: "NTrt0Z" ]
+        
+        guard let request = BeerRequest(requestParams: requestParams) else {
+            XCTFail("Beer request initialisation should not fail")
+        }
+        
+        request.loadBeersWithCompletionHandler() { beers in
+            XCTAssertEqual(beers![0].identifier, returnData)
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(5) { error in
+            XCTAssertNil(error)
+        }
     }
     
 }

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -1,0 +1,23 @@
+//
+//  BeerRequestTests.swift
+//  BreweryDB
+//
+//  Created by Jake on 08/01/2016.
+//  Copyright © 2016 Jake Welton. All rights reserved.
+//
+
+import XCTest
+
+class BeerRequestTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+}

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -55,7 +55,7 @@ class BeerRequestTests: XCTestCase {
     
     func testBeerRequestLoadBeersWithBeerIdReturnsSuccessful() {
         stub(isHost("api.brewerydb.com")) { _ in
-            let stubData = returnData.dataUsingEncoding(NSUTF8StringEncoding)
+            let stubData = self.returnData.dataUsingEncoding(NSUTF8StringEncoding)
             return OHHTTPStubsResponse(data: stubData!, statusCode:200, headers:nil)
         }
         
@@ -64,10 +64,11 @@ class BeerRequestTests: XCTestCase {
         
         guard let request = BeerRequest(requestParams: requestParams) else {
             XCTFail("Beer request initialisation should not fail")
+            return
         }
         
         request.loadBeersWithCompletionHandler() { beers in
-            XCTAssertEqual(beers![0].identifier, returnData)
+            XCTAssertEqual(beers![0].identifier, self.returnData)
             expectation.fulfill()
         }
         

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import BreweryDB
 
 class BeerRequestTests: XCTestCase {
     
@@ -18,6 +19,33 @@ class BeerRequestTests: XCTestCase {
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+    }
+    
+    func testBeerCanBeInitialized() {
+        let requestParams = [
+            BeerRequestParam.Name: "beerName"
+        ]
+        
+        let request: BeerRequest? = BeerRequest(requestParams: requestParams)
+        XCTAssertNotNil(request)
+    }
+ 
+    func testBeerRequestCanBeDeinitialized() {
+        let requestParams = [
+            BeerRequestParam.Name: "beerName"
+        ]
+        
+        var request: BeerRequest? = BeerRequest(requestParams: requestParams)
+        request = nil
+        XCTAssertNil(request)
+    }
+    
+    func testBeerRequestInitWithEmptyParamsReturnsNil() {
+        let requestParams:[BeerRequestParam: String] = [:]
+        
+        var request: BeerRequest? = BeerRequest(requestParams: requestParams)
+        request = nil
+        XCTAssertNil(request)
     }
     
 }

--- a/BreweryDBTests/BeerRequestTests.swift
+++ b/BreweryDBTests/BeerRequestTests.swift
@@ -14,10 +14,7 @@ class BeerRequestTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        stub(isHost(BreweryDBBaseURL.absoluteString)) { _ in
-            let stubData = "Hello World!".dataUsingEncoding(NSUTF8StringEncoding)
-            return OHHTTPStubsResponse(data: stubData!, statusCode:200, headers:nil)
-        }
+        BreweryDBApiKey = "testKey"
         
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -22,13 +22,13 @@ class BeerTests: XCTestCase {
     }
     
     func testBeerCanBeInitializedWithIdentifier() {
-        let beer: Beer? = Beer(name: "Beer identifier")
+        let beer: Beer? = Beer(identifier: "Beer identifier")
 
         XCTAssertNotNil(beer)
     }
     
     func testBeerCanBeDeinitialized() {
-        var beer: Beer? = Beer()
+        var beer: Beer? = Beer(identifier: "Beer Identifier")
         beer = nil
         XCTAssertNil(beer)
     }
@@ -36,7 +36,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetIdentifier() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.identifier = testData
         XCTAssertEqual(testData, beer.identifier)
     }
@@ -44,7 +44,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetName() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.name = testData
         XCTAssertEqual(testData, beer.name)
     }
@@ -52,7 +52,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetDescription() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.description = testData
         XCTAssertEqual(testData, beer.description)
     }
@@ -60,7 +60,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetFoodPairings() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.foodPairings = testData
         XCTAssertEqual(testData, beer.foodPairings)
     }
@@ -68,7 +68,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetOriginalGravity() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.originalGravity = testData
         XCTAssertEqual(testData, beer.originalGravity)
     }
@@ -76,7 +76,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetAbv() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.abv = testData
         XCTAssertEqual(testData, beer.abv)
     }
@@ -84,7 +84,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetIbu() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.ibu = testData
         XCTAssertEqual(testData, beer.ibu)
     }
@@ -92,7 +92,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetGlasswareId() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.glasswareId = testData
         XCTAssertEqual(testData, beer.glasswareId)
     }
@@ -100,7 +100,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetGlass() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.glass = testData
         XCTAssertEqual(testData, beer.glass)
     }
@@ -108,7 +108,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetStyleId() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.styleId = testData
         XCTAssertEqual(testData, beer.styleId)
     }
@@ -116,7 +116,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetStyle() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.style = testData
         XCTAssertEqual(testData, beer.style)
     }
@@ -124,7 +124,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetisOrganic() {
         let testData = true
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.isOrganic = testData
         XCTAssertEqual(testData, beer.isOrganic)
     }
@@ -132,7 +132,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetLabels() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.labels = testData
         XCTAssertEqual(testData, beer.labels)
     }
@@ -140,7 +140,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetServingTemperature() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.servingTemperature = testData
         XCTAssertEqual(testData, beer.servingTemperature)
     }
@@ -148,7 +148,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetServingTemperatureDisplay() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.servingTemperatureDisplay = testData
         XCTAssertEqual(testData, beer.servingTemperatureDisplay)
     }
@@ -156,7 +156,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetStatus() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.status = testData
         XCTAssertEqual(testData, beer.status)
     }
@@ -164,7 +164,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetStatusDisplay() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.statusDisplay = testData
         XCTAssertEqual(testData, beer.statusDisplay)
     }
@@ -172,7 +172,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetAvailableId() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.availableId = testData
         XCTAssertEqual(testData, beer.availableId)
     }
@@ -180,7 +180,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetAvailable() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.available = testData
         XCTAssertEqual(testData, beer.available)
     }
@@ -188,7 +188,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetBeerVariation() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.beerVariation = testData
         XCTAssertEqual(testData, beer.beerVariation)
     }
@@ -196,7 +196,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetYear() {
         let testData = "TestData"
         
-        let beer = Beer()
+        let beer = Beer(identifier: "Beer Identifier")
         beer.year = testData
         XCTAssertEqual(testData, beer.year)
     }

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -21,4 +21,15 @@ class BeerTests: XCTestCase {
         super.tearDown()
     }
     
+    func testBeerCanBeInitialized() {
+        let beer: Beer? = Beer()
+        XCTAssertNotNil(beer)
+    }
+    
+    func testBeerCanBeDeinitialized() {
+        var beer: Beer? = Beer()
+        beer = nil
+        XCTAssertNil(beer)
+    }
+    
 }

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -36,8 +36,7 @@ class BeerTests: XCTestCase {
     func testBeerCanSetIdentifier() {
         let testData = "TestData"
         
-        let beer = Beer(identifier: "Beer Identifier")
-        beer.identifier = testData
+        let beer = Beer(identifier: testData)
         XCTAssertEqual(testData, beer.identifier)
     }
     

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -21,8 +21,8 @@ class BeerTests: XCTestCase {
         super.tearDown()
     }
     
-    func testBeerCanBeInitializedWithName() {
-        let beer: Beer? = Beer(name: "Beer name")
+    func testBeerCanBeInitializedWithIdentifier() {
+        let beer: Beer? = Beer(name: "Beer identifier")
         XCTAssertNotNil(beer)
     }
     

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import BreweryDB
 
 class BeerTests: XCTestCase {
     
@@ -18,6 +19,11 @@ class BeerTests: XCTestCase {
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+    }
+    
+    func testBeerCanBeInitializedWithName() {
+        let beer: Beer? = Beer(name: "Beer name")
+        XCTAssertNotNil(beer)
     }
     
 }

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -32,4 +32,171 @@ class BeerTests: XCTestCase {
         XCTAssertNil(beer)
     }
     
+    func testBeerCanSetIdentifier() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.identifier = testData
+        XCTAssertEqual(testData, beer.identifier)
+    }
+    
+    func testBeerCanSetName() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.name = testData
+        XCTAssertEqual(testData, beer.name)
+    }
+    
+    func testBeerCanSetDescription() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.description = testData
+        XCTAssertEqual(testData, beer.description)
+    }
+    
+    func testBeerCanSetFoodPairings() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.foodPairings = testData
+        XCTAssertEqual(testData, beer.foodPairings)
+    }
+    
+    func testBeerCanSetOriginalGravity() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.originalGravity = testData
+        XCTAssertEqual(testData, beer.originalGravity)
+    }
+    
+    func testBeerCanSetAbv() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.abv = testData
+        XCTAssertEqual(testData, beer.abv)
+    }
+    
+    func testBeerCanSetIbu() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.ibu = testData
+        XCTAssertEqual(testData, beer.ibu)
+    }
+    
+    func testBeerCanSetGlasswareId() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.glasswareId = testData
+        XCTAssertEqual(testData, beer.glasswareId)
+    }
+    
+    func testBeerCanSetGlass() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.glass = testData
+        XCTAssertEqual(testData, beer.glass)
+    }
+    
+    func testBeerCanSetStyleId() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.styleId = testData
+        XCTAssertEqual(testData, beer.styleId)
+    }
+    
+    func testBeerCanSetStyle() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.style = testData
+        XCTAssertEqual(testData, beer.style)
+    }
+    
+    func testBeerCanSetisOrganic() {
+        let testData = true
+        
+        let beer = Beer()
+        beer.isOrganic = testData
+        XCTAssertEqual(testData, beer.isOrganic)
+    }
+    
+    func testBeerCanSetLabels() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.labels = testData
+        XCTAssertEqual(testData, beer.labels)
+    }
+    
+    func testBeerCanSetServingTemperature() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.servingTemperature = testData
+        XCTAssertEqual(testData, beer.servingTemperature)
+    }
+    
+    func testBeerCanSetServingTemperatureDisplay() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.servingTemperatureDisplay = testData
+        XCTAssertEqual(testData, beer.servingTemperatureDisplay)
+    }
+    
+    func testBeerCanSetStatus() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.status = testData
+        XCTAssertEqual(testData, beer.status)
+    }
+    
+    func testBeerCanSetStatusDisplay() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.statusDisplay = testData
+        XCTAssertEqual(testData, beer.statusDisplay)
+    }
+    
+    func testBeerCanSetAvailableId() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.availableId = testData
+        XCTAssertEqual(testData, beer.availableId)
+    }
+    
+    func testBeerCanSetAvailable() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.available = testData
+        XCTAssertEqual(testData, beer.available)
+    }
+    
+    func testBeerCanSetBeerVariation() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.beerVariation = testData
+        XCTAssertEqual(testData, beer.beerVariation)
+    }
+    
+    func testBeerCanSetYear() {
+        let testData = "TestData"
+        
+        let beer = Beer()
+        beer.year = testData
+        XCTAssertEqual(testData, beer.year)
+    }
 }

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -1,0 +1,23 @@
+//
+//  BeerTests.swift
+//  BreweryDB
+//
+//  Created by Jake Welton on 1/3/16.
+//  Copyright © 2016 Jake Welton. All rights reserved.
+//
+
+import XCTest
+
+class BeerTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+}

--- a/BreweryDBTests/BeerTests.swift
+++ b/BreweryDBTests/BeerTests.swift
@@ -21,9 +21,4 @@ class BeerTests: XCTestCase {
         super.tearDown()
     }
     
-    func testBeerCanBeInitializedWithName() {
-        let beer: Beer? = Beer(name: "Beer name")
-        XCTAssertNotNil(beer)
-    }
-    
 }

--- a/BreweryDBTests/BreweryDBTests-Bridging-Header.h
+++ b/BreweryDBTests/BreweryDBTests-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <OHHTTPStubs/OHHTTPStubs.h>

--- a/BreweryDBTests/BreweryDBTests.swift
+++ b/BreweryDBTests/BreweryDBTests.swift
@@ -32,4 +32,8 @@ class BreweryDBTests: XCTestCase {
         XCTAssertEqual(BreweryDBApiKey, apiKey)
     }
     
+    func testBreweryDBBaseURLIsNotNil() {
+        XCTAssertNotNil(BreweryDBBaseURL)
+    }
+    
 }

--- a/BreweryDBTests/BreweryDBTests.swift
+++ b/BreweryDBTests/BreweryDBTests.swift
@@ -21,4 +21,15 @@ class BreweryDBTests: XCTestCase {
         super.tearDown()
     }
     
+    func testBreweryDBApiKeyByDefaultIsNil() {
+        XCTAssertNil(BreweryDBApiKey)
+    }
+    
+    func testBreweryDBApiKeyCanBeSet() {
+        let apiKey = "My API Key"
+        BreweryDBApiKey = apiKey
+        
+        XCTAssertEqual(BreweryDBApiKey, apiKey)
+    }
+    
 }

--- a/BreweryDBTests/BreweryDBTests.swift
+++ b/BreweryDBTests/BreweryDBTests.swift
@@ -21,10 +21,6 @@ class BreweryDBTests: XCTestCase {
         super.tearDown()
     }
     
-    func testBreweryDBApiKeyByDefaultIsNil() {
-        XCTAssertNil(BreweryDBApiKey)
-    }
-    
     func testBreweryDBApiKeyCanBeSet() {
         let apiKey = "My API Key"
         BreweryDBApiKey = apiKey

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -33,4 +33,18 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(url, NSURL(string: "app.mywebservice.com/beer"))
     }
     
+    func testRequestBuilderNSURLExtensionGivenOneGETVarReturnsNSURL() {
+        let baseURL = NSURL(string: "app.mywebservice.com")
+        let url = baseURL?.URLByAppendingGETVariable(BeerRequestParam.Identifier, value: "ID", isFirstVar: true)
+        
+        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com?ids=ID"))
+    }
+    
+    func testRequestBuilderNSURLExtensionGivenTwoGETVarReturnsNSURL() {
+        let baseURL = NSURL(string: "app.mywebservice.com")
+        let urlWithFirst = baseURL?.URLByAppendingGETVariable(BeerRequestParam.Identifier, value: "ID", isFirstVar: true)
+        let url = urlWithFirst?.URLByAppendingGETVariable(BeerRequestParam.Name, value: "beer", isFirstVar: false)
+        
+        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com?ids=ID&name=beer"))
+    }
 }

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -26,5 +26,11 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertNotNil(requestBuilder)
     }
     
+    func testRequestBuilderNSURLExtensionReturnsURLWithRawValue() {
+        let baseURL = NSURL(string: "app.mywebservice.com")
+        let url = baseURL?.URLByAppendingPathComponent(.Beer)
+        
+        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com/beer"))
+    }
     
 }

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -1,0 +1,25 @@
+//
+//  RequestBuilderTests.swift
+//  BreweryDB
+//
+//  Created by Jake Welton on 1/30/16.
+//  Copyright © 2016 Jake Welton. All rights reserved.
+//
+
+import XCTest
+
+class RequestBuilderTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    
+    
+}

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+@testable import BreweryDB
 
 class RequestBuilderTests: XCTestCase {
     
@@ -20,6 +21,10 @@ class RequestBuilderTests: XCTestCase {
         super.tearDown()
     }
     
+    func testRequestBuilderInitsWithRequestEndPoint() {
+        let requestBuilder = RequestBuilder(endPoint: .Beer)
+        XCTAssertNotNil(requestBuilder)
+    }
     
     
 }

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -60,4 +60,17 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, expected)
     }
     
+    func testRequestBuilderWith2ParamsBuildsRequest() {
+        let requestBuilder = RequestBuilder(endPoint: .Beer)
+        let param = [BeerRequestParam.Identifier: "beerIdentifier", BeerRequestParam.Name: "beerName"]
+        
+        let baseURL = BreweryDBBaseURL.absoluteString + "/" + RequestEndPoint.Beer.rawValue
+        let urlWithFirstParam =  baseURL + "?" + BeerRequestParam.Identifier.rawValue + "=" + param[.Identifier]!
+        let expected =  urlWithFirstParam + "&" + BeerRequestParam.Name.rawValue + "=" + param[.Name]!
+        
+        let url = requestBuilder.buildRequest(param)
+        
+        XCTAssertEqual(url.absoluteString, expected)
+    }
+    
 }

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -70,6 +70,14 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(url?.absoluteString, expected)
     }
     
+    func testRequestBuilderWithNoAPIKeyReturnNil() {
+        let requestBuilder = RequestBuilder(endPoint: .Beers)
+        let param = [BeerRequestParam.Identifier: "beerIdentifier", BeerRequestParam.Name: "beerName"]
+        BreweryDBApiKey = nil
+        
+        let url = requestBuilder.buildRequest(param)
+        
+        XCTAssertNil(url)
     }
     
 }

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -47,4 +47,17 @@ class RequestBuilderTests: XCTestCase {
         
         XCTAssertEqual(url, NSURL(string: "app.mywebservice.com?ids=ID&name=beer"))
     }
+    
+    func testRequestBuilderWith1ParamBuildsRequest() {
+        let requestBuilder = RequestBuilder(endPoint: .Beer)
+        let param = [BeerRequestParam.Identifier: "beerIdentifier"]
+        
+        let baseURL = BreweryDBBaseURL.absoluteString + "/" + RequestEndPoint.Beer.rawValue
+        let expected =  baseURL + "?" + BeerRequestParam.Identifier.rawValue + "=beerIdentifier"
+        
+        let url = requestBuilder.buildRequest(param)
+        
+        XCTAssertEqual(url.absoluteString, expected)
+    }
+    
 }

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -26,7 +26,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertNotNil(requestBuilder)
     }
     
-    func testRequestBuilderNSURLExtensionReturnsURLWithRawValue() {
+    func testRequestBuilderNSURLExtensionGivenRawValueReturnsNSURL() {
         let baseURL = NSURL(string: "app.mywebservice.com")
         let url = baseURL?.URLByAppendingPathComponent(.Beer)
         

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -36,13 +36,6 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(url, NSURL(string: "app.mywebservice.com/beers"))
     }
     
-    func testRequestBuilderNSURLExtensionGivenOneGETVarReturnsNSURL() {
-        let baseURL = NSURL(string: "app.mywebservice.com")
-        let url = baseURL?.URLByAppendingGETVariable(BeerRequestParam.Identifier, value: "ID")
-        
-        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com&ids=ID"))
-    }
-    
     func testRequestBuilderWith1ParamBuildsRequest() {
         let requestBuilder = RequestBuilder(endPoint: .Beers)
         let param = [BeerRequestParam.Identifier: "beerIdentifier"]

--- a/BreweryDBTests/RequestBuilderTests.swift
+++ b/BreweryDBTests/RequestBuilderTests.swift
@@ -13,6 +13,9 @@ class RequestBuilderTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
+        
+        BreweryDBApiKey = "testKey"
+        
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
     
@@ -22,55 +25,51 @@ class RequestBuilderTests: XCTestCase {
     }
     
     func testRequestBuilderInitsWithRequestEndPoint() {
-        let requestBuilder = RequestBuilder(endPoint: .Beer)
+        let requestBuilder = RequestBuilder(endPoint: .Beers)
         XCTAssertNotNil(requestBuilder)
     }
     
     func testRequestBuilderNSURLExtensionGivenRawValueReturnsNSURL() {
         let baseURL = NSURL(string: "app.mywebservice.com")
-        let url = baseURL?.URLByAppendingPathComponent(.Beer)
+        let url = baseURL?.URLByAppendingPathComponent(.Beers)
         
-        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com/beer"))
+        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com/beers"))
     }
     
     func testRequestBuilderNSURLExtensionGivenOneGETVarReturnsNSURL() {
         let baseURL = NSURL(string: "app.mywebservice.com")
-        let url = baseURL?.URLByAppendingGETVariable(BeerRequestParam.Identifier, value: "ID", isFirstVar: true)
+        let url = baseURL?.URLByAppendingGETVariable(BeerRequestParam.Identifier, value: "ID")
         
-        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com?ids=ID"))
-    }
-    
-    func testRequestBuilderNSURLExtensionGivenTwoGETVarReturnsNSURL() {
-        let baseURL = NSURL(string: "app.mywebservice.com")
-        let urlWithFirst = baseURL?.URLByAppendingGETVariable(BeerRequestParam.Identifier, value: "ID", isFirstVar: true)
-        let url = urlWithFirst?.URLByAppendingGETVariable(BeerRequestParam.Name, value: "beer", isFirstVar: false)
-        
-        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com?ids=ID&name=beer"))
+        XCTAssertEqual(url, NSURL(string: "app.mywebservice.com&ids=ID"))
     }
     
     func testRequestBuilderWith1ParamBuildsRequest() {
-        let requestBuilder = RequestBuilder(endPoint: .Beer)
+        let requestBuilder = RequestBuilder(endPoint: .Beers)
         let param = [BeerRequestParam.Identifier: "beerIdentifier"]
         
-        let baseURL = BreweryDBBaseURL.absoluteString + "/" + RequestEndPoint.Beer.rawValue
-        let expected =  baseURL + "?" + BeerRequestParam.Identifier.rawValue + "=beerIdentifier"
+        let baseURL = BreweryDBBaseURL.absoluteString + "/" + RequestEndPoint.Beers.rawValue
+        let withKey = baseURL + "?key=" + String(BreweryDBApiKey!)
+        let expected =  withKey + "&" + BeerRequestParam.Identifier.rawValue + "=beerIdentifier"
         
         let url = requestBuilder.buildRequest(param)
         
-        XCTAssertEqual(url.absoluteString, expected)
+        XCTAssertEqual(url?.absoluteString, expected)
     }
     
     func testRequestBuilderWith2ParamsBuildsRequest() {
-        let requestBuilder = RequestBuilder(endPoint: .Beer)
+        let requestBuilder = RequestBuilder(endPoint: .Beers)
         let param = [BeerRequestParam.Identifier: "beerIdentifier", BeerRequestParam.Name: "beerName"]
         
-        let baseURL = BreweryDBBaseURL.absoluteString + "/" + RequestEndPoint.Beer.rawValue
-        let urlWithFirstParam =  baseURL + "?" + BeerRequestParam.Identifier.rawValue + "=" + param[.Identifier]!
+        let baseURL = BreweryDBBaseURL.absoluteString + "/" + RequestEndPoint.Beers.rawValue
+        let withKey = baseURL + "?key=" + String(BreweryDBApiKey!)
+        let urlWithFirstParam =  withKey + "&" + BeerRequestParam.Identifier.rawValue + "=" + param[.Identifier]!
         let expected =  urlWithFirstParam + "&" + BeerRequestParam.Name.rawValue + "=" + param[.Name]!
         
         let url = requestBuilder.buildRequest(param)
         
-        XCTAssertEqual(url.absoluteString, expected)
+        XCTAssertEqual(url?.absoluteString, expected)
+    }
+    
     }
     
 }

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,0 @@
-github "Alamofire/Alamofire" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "Alamofire/Alamofire" "3.1.4"

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,12 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '8.0'
+# Uncomment this line if you're using Swift
+# use_frameworks!
+
+target 'BreweryDB' do
+
+end
+
+target 'BreweryDBTests' do
+	pod 'OHHTTPStubs'
+end

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 # Uncomment this line to define a global platform for your project
 # platform :ios, '8.0'
 # Uncomment this line if you're using Swift
-# use_frameworks!
+use_frameworks!
 
 target 'BreweryDB' do
 
@@ -9,4 +9,5 @@ end
 
 target 'BreweryDBTests' do
 	pod 'OHHTTPStubs'
+	pod 'OHHTTPStubs/Swift'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,9 +12,12 @@ PODS:
   - OHHTTPStubs/NSURLSession (4.7.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (4.7.0)
+  - OHHTTPStubs/Swift (4.7.0):
+    - OHHTTPStubs/Core
 
 DEPENDENCIES:
   - OHHTTPStubs
+  - OHHTTPStubs/Swift
 
 SPEC CHECKSUMS:
   OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - OHHTTPStubs (4.7.0):
+    - OHHTTPStubs/Default (= 4.7.0)
+  - OHHTTPStubs/Core (4.7.0)
+  - OHHTTPStubs/Default (4.7.0):
+    - OHHTTPStubs/Core
+    - OHHTTPStubs/JSON
+    - OHHTTPStubs/NSURLSession
+    - OHHTTPStubs/OHPathHelpers
+  - OHHTTPStubs/JSON (4.7.0):
+    - OHHTTPStubs/Core
+  - OHHTTPStubs/NSURLSession (4.7.0):
+    - OHHTTPStubs/Core
+  - OHHTTPStubs/OHPathHelpers (4.7.0)
+
+DEPENDENCIES:
+  - OHHTTPStubs
+
+SPEC CHECKSUMS:
+  OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0
+
+COCOAPODS: 0.39.0


### PR DESCRIPTION
## Basic Beer Implementation

This pull request includes a basic implementation of beers. It includes the basics for building URLs within the BreweryDB framework as well as functionality for fetching beers from the Rest API. Global variables are used for setting the API key and NSURLSession is used to perform the networking request.

All dependencies have been removed as they are not required with the exception of OHHTTPStubs which is used within unit tests for stubbing network requests.
